### PR TITLE
build: set better timeout

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ on:
 jobs:
     check:
         runs-on: ubuntu-latest
+        timeout-minutes: 60
         steps:
             - uses: actions/checkout@v2
             - uses: actions/setup-java@v2
@@ -18,6 +19,7 @@ jobs:
     publish:
         needs: check
         runs-on: ubuntu-latest
+        timeout-minutes: 60
         steps:
             - uses: actions/checkout@v2
             - uses: actions/setup-java@v2
@@ -35,6 +37,7 @@ jobs:
     release:
         needs: publish
         runs-on: ubuntu-latest
+        timeout-minutes: 60
         steps:
             - uses: actions/checkout@v2
             - uses: actions/create-release@v1


### PR DESCRIPTION
Set missing timeouts to 60 to avoid using the default of 6 hours.

See https://github.com/Doist/Issues/issues/5259