### PR TITLE
Add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> **Warning** — Not actively maintained.
+
 # Ktlint Gradle Plugin
 
 This plugin is mainly designed to run [Ktlint](https://github.com/pinterest/ktlint) for changed `kt` files.


### PR DESCRIPTION
We're using [Detekt](https://detekt.dev/) now.